### PR TITLE
Fix contain() options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,7 +136,7 @@ internals.match = function (err, types) {
             }
         }
         else if (typeof type === 'object') {
-            if (Hoek.contain(err, type, { deep: true })) {
+            if (Hoek.contain(err, type, { deep: true, part: true })) {
                 return true;
             }
         }


### PR DESCRIPTION
This fixes the usage of `Hoek.contain()` to set the `part` option as intended.

This is required to continue working once https://github.com/hapijs/hoek/pull/277 is merged.