### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v3
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2017-2020, Sideway Inc, and project contributors  
+Copyright (c) 2017-2022, Project contributors
+Copyright (c) 2017-2020, Sideway Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x"
+    "@hapi/boom": "10.x.x",
+    "@hapi/hoek": "10.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.x.x",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "25.0.0-beta.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "10.x.x",
-    "@hapi/hoek": "10.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "9.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
     "@hapi/lab": "25.0.0-beta.1"
   },


### PR DESCRIPTION
 - Test on node v14+.
 - Update to node v18-compatible versions of hoek, boom, lab, and code.

If this looks good, this will go out as bounce v3.