### PR TITLE
Much faster rethrow(err, 'system')

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const Assert = require('assert');
+
+const AssertError = require('@hapi/hoek/assertError');
+
+
+module.exports = [
+
+    // Node
+
+    Assert.AssertionError,
+
+    // Hoek
+
+    AssertError
+];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Assert = require('assert');
-
 const Boom = require('@hapi/boom');
-const Hoek = require('@hapi/hoek');
+const Contain = require('@hapi/hoek/contain');
+
+const Assertions = require('./assertions');
 
 
 const internals = {
@@ -18,13 +18,7 @@ const internals = {
         TypeError,
         URIError,
 
-        // Node
-
-        Assert.AssertionError,
-
-        // Hoek
-
-        Hoek.AssertError
+        ...Assertions
     ]
 };
 
@@ -135,7 +129,7 @@ internals.match = function (err, types) {
             }
         }
         else if (typeof type === 'object') {
-            if (Hoek.contain(err, type, { deep: true, part: true })) {
+            if (Contain(err, type, { deep: true, part: true })) {
                 return true;
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const Assertions = require('./assertions');
 
 
 const internals = {
+    symbol: Symbol('SystemError'),
     system: [
 
         // JavaScript
@@ -21,6 +22,30 @@ const internals = {
         ...Assertions
     ]
 };
+
+
+internals.slow = (() => {
+
+    // Add hidden property to prototype that all instances will have
+
+    const slow = [];
+    const defaultHasInstance = Object[Symbol.hasInstance];
+    for (const system of internals.system) {
+        if (system[Symbol.hasInstance] !== defaultHasInstance) {      // Skip classes that use custom instanceof checks
+            slow.push(system);
+            continue;
+        }
+
+        Object.defineProperty(system.prototype, internals.symbol, {
+            configurable: false,
+            enumerable: false,
+            writable: false,
+            value: true
+        });
+    }
+
+    return slow;
+})();
 
 
 exports.rethrow = function (err, types, options = {}) {
@@ -99,7 +124,11 @@ exports.isSystem = function (err) {
         return false;
     }
 
-    for (const system of internals.system) {
+    if (err[internals.symbol] === true) {
+        return true;
+    }
+
+    for (const system of internals.slow) {
         if (err instanceof system) {
             return true;
         }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,20 @@
 'use strict';
 
+// Add custom assertion to assertion list. Must be done before requiring Bounce
+
+class HasInstanceCheckError {
+
+    static [Symbol.hasInstance](instance) {
+
+        return instance.message === 'custom-error';
+    }
+}
+
+const Assertions = require('../lib/assertions');
+
+Assertions.push(HasInstanceCheckError);
+
+
 const Assert = require('assert');
 
 const Code = require('@hapi/code');
@@ -518,6 +533,11 @@ describe('Bounce', () => {
         it('identifies node AssertionError as system', () => {
 
             expect(Bounce.isSystem(new Assert.AssertionError({}))).to.be.true();
+        });
+
+        it('identifies custom assertion Error as system', () => {
+
+            expect(Bounce.isSystem(new Error('custom-error'))).to.be.true();
         });
 
         it('identifies hoek Error as system', () => {


### PR DESCRIPTION
The main aim of this PR is to apply a hack that dramatically speeds up standard `Bounce.rethrow(err, 'system')` calls (when not matching).

This is done by adding a hidden property to each system error prototype, which can be tested for quickly. This replaces a series of slow `instanceof` checks. In my quick benchmark, I saw *a ~50x speed increase!*

Care has been taken to implement this in a compatible manner, since system errors with custom `[Symbol.hasInstance]` logic could otherwise fail. Since none of the existing system errors currently does this, I have had to add one such error during testing, to retain coverage.